### PR TITLE
Add HTML5 drawing app

### DIFF
--- a/drawing-app/index.html
+++ b/drawing-app/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Drawing App</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="toolbar">
+        <button data-tool="pencil" class="active">Pencil</button>
+        <button data-tool="eraser">Eraser</button>
+        <button data-tool="rect">Rectangle</button>
+        <button data-tool="circle">Circle</button>
+        <button data-tool="line">Line</button>
+        <button data-tool="text">Text</button>
+        <input type="color" id="colorPicker" value="#000000">
+        <input type="range" id="sizePicker" min="1" max="50" value="5">
+        <button id="undo">Undo</button>
+        <button id="redo">Redo</button>
+        <button id="save">Save</button>
+        <input type="file" id="imageLoader" accept="image/*" />
+    </div>
+    <canvas id="canvas" width="800" height="600"></canvas>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/drawing-app/script.js
+++ b/drawing-app/script.js
@@ -1,0 +1,116 @@
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+let drawing = false;
+let currentTool = 'pencil';
+let startX, startY;
+let undoStack = [];
+let redoStack = [];
+
+function saveState() {
+    undoStack.push(canvas.toDataURL());
+    redoStack = [];
+}
+
+function restoreState(stack, opposite) {
+    if (stack.length) {
+        opposite.push(canvas.toDataURL());
+        const img = new Image();
+        img.src = stack.pop();
+        img.onload = () => {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            ctx.drawImage(img, 0, 0);
+        };
+    }
+}
+
+canvas.addEventListener('mousedown', (e) => {
+    drawing = true;
+    ctx.strokeStyle = document.getElementById('colorPicker').value;
+    ctx.lineWidth = document.getElementById('sizePicker').value;
+    ctx.lineCap = 'round';
+    startX = e.offsetX;
+    startY = e.offsetY;
+    if (currentTool === 'pencil' || currentTool === 'eraser') {
+        ctx.beginPath();
+        ctx.moveTo(startX, startY);
+    }
+});
+
+canvas.addEventListener('mousemove', (e) => {
+    if (!drawing) return;
+    const x = e.offsetX;
+    const y = e.offsetY;
+    if (currentTool === 'pencil') {
+        ctx.lineTo(x, y);
+        ctx.stroke();
+    } else if (currentTool === 'eraser') {
+        ctx.strokeStyle = '#ffffff';
+        ctx.lineTo(x, y);
+        ctx.stroke();
+    }
+});
+
+canvas.addEventListener('mouseup', (e) => {
+    if (!drawing) return;
+    drawing = false;
+    const x = e.offsetX;
+    const y = e.offsetY;
+    if (currentTool === 'rect') {
+        ctx.strokeRect(startX, startY, x - startX, y - startY);
+    } else if (currentTool === 'circle') {
+        const radius = Math.hypot(x - startX, y - startY);
+        ctx.beginPath();
+        ctx.arc(startX, startY, radius, 0, Math.PI * 2);
+        ctx.stroke();
+    } else if (currentTool === 'line') {
+        ctx.beginPath();
+        ctx.moveTo(startX, startY);
+        ctx.lineTo(x, y);
+        ctx.stroke();
+    } else if (currentTool === 'text') {
+        const text = prompt('Enter text');
+        if (text) ctx.fillText(text, x, y);
+    }
+    saveState();
+});
+
+canvas.addEventListener('mouseleave', () => {
+    drawing = false;
+});
+
+// Tool buttons
+for (const btn of document.querySelectorAll('#toolbar button[data-tool]')) {
+    btn.addEventListener('click', () => {
+        document.querySelector('#toolbar button.active').classList.remove('active');
+        btn.classList.add('active');
+        currentTool = btn.dataset.tool;
+    });
+}
+
+// Undo/Redo
+document.getElementById('undo').addEventListener('click', () => restoreState(undoStack, redoStack));
+document.getElementById('redo').addEventListener('click', () => restoreState(redoStack, undoStack));
+
+document.getElementById('save').addEventListener('click', () => {
+    const link = document.createElement('a');
+    link.download = 'drawing.png';
+    link.href = canvas.toDataURL();
+    link.click();
+});
+
+document.getElementById('imageLoader').addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+        const img = new Image();
+        img.onload = () => {
+            ctx.drawImage(img, 0, 0);
+            saveState();
+        };
+        img.src = evt.target.result;
+    };
+    reader.readAsDataURL(file);
+});
+
+saveState();

--- a/drawing-app/styles.css
+++ b/drawing-app/styles.css
@@ -1,0 +1,18 @@
+body {
+    margin: 0;
+    font-family: sans-serif;
+}
+#toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    padding: 5px;
+    background: #f0f0f0;
+    border-bottom: 1px solid #ccc;
+}
+#canvas {
+    display: block;
+}
+button.active {
+    background: #add8e6;
+}


### PR DESCRIPTION
## Summary
- implement simple drawing application using HTML5 Canvas
- include 10 features: pencil, eraser, rectangle, circle, line, text, color picker, brush size, undo/redo, save/export, and image import

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6874db0a3c4883278300374fd2602bdf